### PR TITLE
Extend functionality to allow notifications on performance regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 performance-plugin
 ==================
+
+This Hudson plugin allows you to see how your tests perform over time.
+
+The plugin is capable to notify regression in performance (ms and percentage).
+For example you could configure a build to fail when::
+
+    Errors count > 3 OR (Performance Regression > 15% AND Performance Regression Time > 2000ms)

--- a/pom.xml
+++ b/pom.xml
@@ -1,114 +1,120 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  
-  <parent>
-    <groupId>org.eclipse.hudson.plugins</groupId>
-    <artifactId>hudson-plugin-parent</artifactId>
-    <version>3.0.0</version>
-  </parent>
-  
-  <groupId>org.hudsonci.plugins</groupId>
-  <artifactId>performance</artifactId>
-  <packaging>hpi</packaging>
-  <version>1.8-h-3-SNAPSHOT</version>
-  <name>Performance plugin</name>
-  <url>http://wiki.hudson-ci.org/display/HUDSON/Performance+Plugin</url>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <properties>
-    <hudsonTags>report</hudsonTags>
-  </properties>
+    <parent>
+        <groupId>org.eclipse.hudson.plugins</groupId>
+        <artifactId>hudson-plugin-parent</artifactId>
+        <version>3.0.0</version>
+    </parent>
 
-  <developers>
-    <developer>
-      <id>schristou88</id>
-      <name>Steven Christou</name>
-      <email>schristou88@gmail.com</email>
-      <roles>
-          <role>
-              Maintainer
-          </role>
-      </roles>
-    </developer>
-  </developers>
+    <groupId>org.hudsonci.plugins</groupId>
+    <artifactId>performance</artifactId>
+    <packaging>hpi</packaging>
+    <version>1.8-h-4</version>
+    <name>Performance plugin</name>
+    <url>http://wiki.hudson-ci.org/display/HUDSON/Performance+Plugin</url>
 
-  <contributors>
-    <contributor>
-      <name>Manuel Carrasco Monino</name>
-      <email>manolo@apache.org</email>
-      <roles>
-        <role>
-          Original Developer
-        </role>
-      </roles>
-    </contributor>
-    <contributor>
-      <name>Vergnes</name>
-      <email>vergnes@dev.java.net</email>
-      <roles>
-        <role>
-          Original Developer
-        </role>
-      </roles>
-    </contributor>
-    <contributor>
-      <name>Arnaud Espy</name>
-      <email>aespy@dev.java.net</email>
-      <roles>
-        <role>
-          Original Developer
-        </role>
-      </roles>
-    </contributor>
-  </contributors>
+    <properties>
+        <hudsonTags>report</hudsonTags>
+    </properties>
 
-  <licenses>
-    <license>
-      <name>The MIT license</name>
-      <url>http://www.opensource.org/licenses/mit-license.php</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
+    <developers>
+        <developer>
+            <id>schristou88</id>
+            <name>Steven Christou</name>
+            <email>schristou88@gmail.com</email>
+            <roles>
+                <role>
+                    Maintainer
+                </role>
+            </roles>
+        </developer>
+    </developers>
 
-  <scm>
-    <connection>scm:git:git://github.com/hudson3-plugins/performance-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:hudson3-plugins/performance-plugin.git</developerConnection>
-    <url>https://github.com/hudson3-plugins/performance-plugin</url>
-  </scm>
+    <contributors>
+        <contributor>
+            <name>Manuel Carrasco Monino</name>
+            <email>manolo@apache.org</email>
+            <roles>
+                <role>
+                    Original Developer
+                </role>
+            </roles>
+        </contributor>
+        <contributor>
+            <name>Vergnes</name>
+            <email>vergnes@dev.java.net</email>
+            <roles>
+                <role>
+                    Original Developer
+                </role>
+            </roles>
+        </contributor>
+        <contributor>
+            <name>Arnaud Espy</name>
+            <email>aespy@dev.java.net</email>
+            <roles>
+                <role>
+                    Original Developer
+                </role>
+            </roles>
+        </contributor>
+    </contributors>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.hudsonci.plugins</groupId>
-      <artifactId>jfreechart-plugin</artifactId>
-      <version>1.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymockclassextension</artifactId>
-      <version>2.4</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
+    <licenses>
+        <license>
+            <name>The MIT license</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
-  <build>
-    <plugins>
-<!--
-      <plugin>
-        <groupId>com.relativitas.maven.plugins</groupId>
-        <artifactId>maven-java-formatter-plugin</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
-        <configuration>
-          <compilerSource>1.5</compilerSource>
-          <compilerCompliance>1.5</compilerCompliance>
-          <compilerTargetPlatform>1.5</compilerTargetPlatform>
-          <configFile>src/main/tools/format.xml</configFile>
-          <directories>
-            <directory>src/main/java</directory>
-          </directories>
-        </configuration>
-      </plugin>
--->
-    </plugins>
-  </build>
+    <scm>
+        <connection>scm:git:git://github.com/hudson3-plugins/performance-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:hudson3-plugins/performance-plugin.git</developerConnection>
+        <url>https://github.com/hudson3-plugins/performance-plugin</url>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hudsonci.plugins</groupId>
+            <artifactId>jfreechart-plugin</artifactId>
+            <version>1.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymockclassextension</artifactId>
+            <version>2.4</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.hudson.tools</groupId>
+                <artifactId>maven-hpi-plugin</artifactId>
+                <version>3.0.2</version>
+            </plugin>
+            <!--
+                  <plugin>
+                    <groupId>com.relativitas.maven.plugins</groupId>
+                    <artifactId>maven-java-formatter-plugin</artifactId>
+                    <version>0.2.0-SNAPSHOT</version>
+                    <configuration>
+                      <compilerSource>1.5</compilerSource>
+                      <compilerCompliance>1.5</compilerCompliance>
+                      <compilerTargetPlatform>1.5</compilerTargetPlatform>
+                      <configFile>src/main/tools/format.xml</configFile>
+                      <directories>
+                        <directory>src/main/java</directory>
+                      </directories>
+                    </configuration>
+                  </plugin>
+            -->
+        </plugins>
+    </build>
 
 </project>  
   

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <hudsonTags>report</hudsonTags>
+        <maven-hpi-plugin.version>3.0.2</maven-hpi-plugin.version>
     </properties>
 
     <developers>
@@ -92,11 +93,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.eclipse.hudson.tools</groupId>
-                <artifactId>maven-hpi-plugin</artifactId>
-                <version>3.0.2</version>
-            </plugin>
             <!--
                   <plugin>
                     <groupId>com.relativitas.maven.plugins</groupId>

--- a/src/main/java/hudson/plugins/performance/AbstractReport.java
+++ b/src/main/java/hudson/plugins/performance/AbstractReport.java
@@ -62,6 +62,8 @@ public abstract class AbstractReport {
   abstract public String getHttpCode();
 
   abstract public long getAverageDiff();
+
+  abstract public long getAverageDiffPercent();
   
   abstract public long getMedianDiff();
   

--- a/src/main/java/hudson/plugins/performance/PerformanceReport.java
+++ b/src/main/java/hudson/plugins/performance/PerformanceReport.java
@@ -205,6 +205,13 @@ public class PerformanceReport extends AbstractReport implements
       }
       return getAverage() - lastBuildReport.getAverage();
   }
+
+  public long getAverageDiffPercent() {
+    if (lastBuildReport == null) {
+      return 0;
+    }
+    return (getAverage() - lastBuildReport.getAverage()) * 100 / lastBuildReport.getAverage();
+  }
   
   public long getMedianDiff() {
       if ( lastBuildReport == null ) {

--- a/src/main/java/hudson/plugins/performance/PerformanceReport.java
+++ b/src/main/java/hudson/plugins/performance/PerformanceReport.java
@@ -210,6 +210,10 @@ public class PerformanceReport extends AbstractReport implements
     if (lastBuildReport == null) {
       return 0;
     }
+    if (lastBuildReport.getAverage() == 0) {
+      // avoid division by 0
+      return 0;
+    }
     return (getAverage() - lastBuildReport.getAverage()) * 100 / lastBuildReport.getAverage();
   }
   

--- a/src/main/java/hudson/plugins/performance/PerformanceReport.java
+++ b/src/main/java/hudson/plugins/performance/PerformanceReport.java
@@ -130,7 +130,7 @@ public class PerformanceReport extends AbstractReport implements
   }
 
   public UriReport getDynamic(String token) throws IOException {
-    return getUriReportMap().get(token);
+    return getUriReportMap().getOrDefault(token, null);
   }
 
   public HttpSample getHttpSample() {

--- a/src/main/java/hudson/plugins/performance/UriReport.java
+++ b/src/main/java/hudson/plugins/performance/UriReport.java
@@ -183,6 +183,13 @@ public class UriReport extends AbstractReport implements ModelObject,
       }
       return getAverage() - lastBuildUriReport.getAverage();
   }
+
+  public long getAverageDiffPercent() {
+    if (lastBuildUriReport == null) {
+      return 0;
+    }
+    return (getAverage() - lastBuildUriReport.getAverage()) * 100 / lastBuildUriReport.getAverage();
+  }
   
   public long getMedianDiff() {
       if ( lastBuildUriReport == null ) {

--- a/src/main/java/hudson/plugins/performance/UriReport.java
+++ b/src/main/java/hudson/plugins/performance/UriReport.java
@@ -193,6 +193,10 @@ public class UriReport extends AbstractReport implements ModelObject,
     if (lastBuildUriReport == null) {
       return 0;
     }
+    if (lastBuildUriReport.getAverage() == 0) {
+      // avoid division by 0
+      return 0;
+    }
     return (getAverage() - lastBuildUriReport.getAverage()) * 100 / lastBuildUriReport.getAverage();
   }
   

--- a/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.jelly
@@ -9,29 +9,48 @@
   </f:entry>
   <f:entry title="${%Performance threshold}"
       description="${%Threshold.Description}">
-    <table width="250px">
+    <table width="70%">
       <thead>
         <tr>
           <td/>
-          <td colspan="2">
+          <td colspan="4">
             <img src="${rootURL}/images/16x16/yellow.gif" alt="100%" /> ${%Unstable}
           </td>
-          <td colspan="2">
+          <td colspan="4">
             <img src="${rootURL}/images/16x16/red.gif" alt="100%" /> ${%Failed}
           </td>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <td style="vertical-align:middle">${%Thresholds}:</td>
-          <td>
+          <td style="vertical-align:middle">${%Thresholds Errors}:</td>
+          <td colspan="3">
             <f:textbox field="errorUnstableThreshold" />
           </td>
           <td> % </td>
-          <td>
+          <td colspan="3">
             <f:textbox field="errorFailedThreshold" />
           </td>
           <td> % </td>
+        </tr>
+        <tr>
+          <td style="vertical-align:middle">${%Thresholds Performance}:</td>
+          <td>
+            <f:textbox field="performanceUnstableThreshold" />
+          </td>
+          <td> % </td>
+          <td>
+            <f:textbox field="performanceTimeUnstableThreshold" />
+          </td>
+          <td> ms </td>
+          <td>
+            <f:textbox field="performanceFailedThreshold" />
+          </td>
+          <td> % </td>
+          <td>
+            <f:textbox field="performanceTimeFailedThreshold" />
+          </td>
+          <td> ms </td>
         </tr>
       </tbody>    
     </table>  

--- a/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.properties
+++ b/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.properties
@@ -6,12 +6,7 @@ Performance\ threshold=Performance threshold
 
 Threshold.Description=\
    Specify the error or performance regression threshold (percentage/ms), that can set the build state to unstable or \
-   failed (a negative value means: unused threshold). Performance indicators are used with AND in between; between \
-    Error and Performance indicators OR boolean condition is applied, to determine if the build is failed/unstable.\n\
-    E.g. Errors count > 3 OR (Performance Regression > 15% AND Performance Regression Time > 2000ms) => Failed \n\
-   This is with the intention to allow avoidance of small tests fluctuation (e.g. Unit Test timing increased from \
-   running in 1ms to 2 ms is a regression of 100%, but not relevant for the performance of the application, as it \
-   probably fluctuates with the machine load at the moment of run).
+   failed (a negative value means: unused threshold).
 
 Thresholds\ Errors=Thresholds Errors
 Thresholds\ Performance=Thresholds Performance Regression

--- a/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.properties
+++ b/src/main/resources/hudson/plugins/performance/PerformancePublisher/config.properties
@@ -3,10 +3,18 @@
 Performance\ report=Performance report
 
 Performance\ threshold=Performance threshold
+
 Threshold.Description=\
-   Specify the error percentage threshold that set the build \
-   unstable or failed (a negative value means: don't use this threshold).
-Thresholds=Thresholds
+   Specify the error or performance regression threshold (percentage/ms), that can set the build state to unstable or \
+   failed (a negative value means: unused threshold). Performance indicators are used with AND in between; between \
+    Error and Performance indicators OR boolean condition is applied, to determine if the build is failed/unstable.\n\
+    E.g. Errors count > 3 OR (Performance Regression > 15% AND Performance Regression Time > 2000ms) => Failed \n\
+   This is with the intention to allow avoidance of small tests fluctuation (e.g. Unit Test timing increased from \
+   running in 1ms to 2 ms is a regression of 100%, but not relevant for the performance of the application, as it \
+   probably fluctuates with the machine load at the moment of run).
+
+Thresholds\ Errors=Thresholds Errors
+Thresholds\ Performance=Thresholds Performance Regression
 
 Unstable=Unstable
 Failed=Failed

--- a/src/main/resources/hudson/plugins/performance/UriReport/index.jelly
+++ b/src/main/resources/hudson/plugins/performance/UriReport/index.jelly
@@ -28,6 +28,9 @@
           </tr>
         </j:forEach>
       </table>
+
+      <h3>${%Performance Breakdown}</h3>
+      <img class="trend" src="./respondingTimeGraph?width=600&amp;height=225&amp;" width="600" height="225" />
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/performance/tags/captionLine.jelly
+++ b/src/main/resources/hudson/plugins/performance/tags/captionLine.jelly
@@ -7,6 +7,7 @@
     <th>${%samples diff}</th>
     <th>${%Average} (ms)</th>
     <th>${%Average diff} (ms)</th>
+    <th>${%Average diff} (%)</th>
     <th>${%Median} (ms)</th>
     <th>${%Median diff} (ms)</th>
     <th>${%Line90} (ms)</th>

--- a/src/main/resources/hudson/plugins/performance/tags/summaryTable.jelly
+++ b/src/main/resources/hudson/plugins/performance/tags/summaryTable.jelly
@@ -5,6 +5,7 @@
   <td class="${h.ifThenElse(it.getSizeDiff()>=0,'green','red')}">${it.getSizeDiff()}</td>
   <td>${it.getAverage()}</td>
   <td class="${h.ifThenElse(it.getAverageDiff()>0,'red','green')}">${it.getAverageDiff()}</td>
+  <td class="${h.ifThenElse(it.getAverageDiffPercent()>0,'red','green')}">${it.getAverageDiffPercent()}</td>
   <td>${it.getMedian()}</td>
   <td class="${h.ifThenElse(it.getMedianDiff()>0,'red','green')}">${it.getMedianDiff()}</td>
   <td>${it.get90Line()}</td>

--- a/src/main/webapp/help.html
+++ b/src/main/webapp/help.html
@@ -1,15 +1,29 @@
-<div>This plugin understands the <a
-	href="http://jakarta.apache.org/jmeter/">JMeter</a> analysis report XML
-format and the <a href="http://www.soapui.org/"> SOAPUI report in
-JUnit format</a>. <br/>
-This plug-in does not perform the actual analysis; it only
-displays useful information about analysis results, such as average
-responding time, historical result trend, web UI for viewing analysis
-reports, and so on.
+<div>
+    <p>
+        This plugin understands the <a href="http://jakarta.apache.org/jmeter/">JMeter</a> analysis report XML
+        format and the <a href="http://www.soapui.org/"> SOAPUI report in JUnit format</a>. <br/>
+        This plug-in does not perform the actual analysis; it only displays useful information about analysis
+        results, such as average responding time, historical result trend, web UI for viewing analysis reports,
+        and so on.
+    </p>
+    <p>
+        To use this feature, first set up your build to run tests, then select the adequate parser for your
+        tests (JMeter or JUnit) and finally you have to specify the path to the different performance XML files,
+        by default the plugin will use the <tt>**/*.jtl</tt> pattern for JMeter, and <tt>**/TEST*.xml</tt>
+        for JUnit tests.
+    </p>
 
-<p>
-To use this feature, first set up your build to run tests, then select the adequate parser for your tests (JMeter or JUnit) and finally
-you have to specify the path to the different performance XML files, by default the plugin will use the <tt>**/*.jtl</tt> pattern for
-JMeter, and <tt>**/TEST*.xml</tt> for JUnit tests.
-</p>
+    <p>
+        This plugin is capable to notify regression in performance (ms and percentage).
+        For example you could configure a build to fail when: <br/>
+
+        <tt>"Errors Count" > 3 OR ("Performance Regression" > 15% AND "Performance Regression Time" > 2000ms)</tt> <br/>
+
+        <b>NOTE:</b> Between Error and Performance thresholds OR boolean condition is applied, while between the
+        2 performance thresholds AND is applied. This happens, to allow avoidance of small test fluctuations: <br/>
+        E.g. if a Unit Test run-time increased from 1ms to 2ms, this is a regression of 100%, but is not relevant
+        for the performance of the application, as it probably fluctuates with the machine load at the moment of run;
+        while for a test of 20 seconds, an increase of 15% in run time, should point a performance regression in
+        the current implementation.
+    </p>
 </div>


### PR DESCRIPTION
I did the following changes:
- update pom property to allow build with JDK 7 or 8
- add column "Average diff %" to performance tables
- show trend graph on UriReport also
- modified the way a build status is computed, to allow failures in case performance regression happens from one build to another 
- I also changed the version number in pom.xml. 

I hope these changes are fitting to the strategy you have established for this plugin. 
